### PR TITLE
Remove blank lines before display equations

### DIFF
--- a/front-matter/preface.tex
+++ b/front-matter/preface.tex
@@ -1,3 +1,6 @@
+\bgroup
+\setlength{\parindent}{0cm}
+\setlength{\parskip}{0.3cm}
 Quantum computing is an emerging field poised to revolutionize multiple
 disciplines, including cryptography, optimization, machine learning, and
 scientific simulations. This handbook serves as a structured compilation of
@@ -7,9 +10,6 @@ discussions, and supplementary readings throughout the semester, aiming to
 reinforce core concepts and provide a comprehensive reference for students
 and enthusiasts alike.
 
-\vspace{0.3cm}
-
-\noindent
 The notes begin with foundational mathematical principles, including linear
 algebra and probability theory. Subsequent sections explore quantum circuits,
 essential quantum gates, multi-qubit systems, and fundamental quantum
@@ -18,21 +18,16 @@ phases of the handbook introduce advanced topics, including variational
 quantum algorithms, quantum simulation techniques, and emerging paradigms in
 quantum machine learning and optimization.
 
-\vspace{0.3cm}
-
-\noindent
 I would like to extend my deepest gratitude to \textbf{Professor Tirthak Patel},
 whose guidance and expertise have been instrumental in shaping my
 understanding of quantum computing. I am also grateful to my peers for the
 collaborative discussions that enriched my learning experience.
 
-\vspace{0.3cm}
-
-\noindent
 As quantum computing continues to evolve, these notes will remain a living
 document, subject to refinement and expansion. I welcome feedback,
 corrections, and contributions from readers to ensure the accuracy and
 completeness of this resource.
+\egroup
 
 \vspace{1cm}
 

--- a/lectures/phase-i/lecture2.tex
+++ b/lectures/phase-i/lecture2.tex
@@ -11,7 +11,6 @@ complex numbers ($\mathbb{C}$).}
 \subsection*{Column Vectors} \index{vector!column| see{ ket }}
 
 A column vector is a vertical arrangement of numbers:
-
 \[
   \mathbf{v} =
   \begin{bmatrix}
@@ -26,7 +25,6 @@ A column vector is a vertical arrangement of numbers:
 
 A row vector is the complex conjugate transpose \textbf{vector}
 \index{vector!adjoint} of a column vector:
-
 \[
   \mathbf{v}^\dagger =
   \begin{bmatrix}
@@ -56,7 +54,6 @@ In quantum computing, vectors are represented using \textbf{Dirac notation}
 
 \dfn{Euler's Formula}{Euler's formula \index{Euler's formula} relates complex
   exponentials to trigonometric functions:
-
   \[
     e^{i\omega} = \cos(\omega) + i\sin(\omega)
   \]
@@ -65,7 +62,6 @@ This is fundamental in representing quantum states and transformations.}
 
 \dfn{Inner Product}{The \textbf{inner product} \index{vector!inner product}
   of two vectors $\mathbf{v}, \mathbf{w} \in \mathbb{C}^n$ is defined as:
-
   \[
     \langle \mathbf{v}, \mathbf{w} \rangle = \mathbf{v}^\dagger \mathbf{w} =
     \sum_{i=1}^n \overline{v_i}w_i
@@ -76,14 +72,12 @@ This is fundamental in representing quantum states and transformations.}
   \ex{Inner Product Example}{
 
     Given two vectors:
-
     \[
       \mathbf{v} = \begin{bmatrix} 1 \\ i \end{bmatrix}, \quad
       \mathbf{w} = \begin{bmatrix} 2 \\ 1 \end{bmatrix}
     \]
 
     The inner product is:
-
     \[
       \langle \mathbf{v}, \mathbf{w} \rangle = \begin{bmatrix} 1 & -i
       \end{bmatrix}
@@ -94,7 +88,6 @@ This is fundamental in representing quantum states and transformations.}
   We also have the following property that the inner product is equivalent to
   the square of the Euclidean norm of a vector:
   \index{vector!Euclidean norm}
-
   \[
     \langle \mathbf{v}, \mathbf{v} \rangle = \|\mathbf{v}\|^2
   \]
@@ -103,7 +96,6 @@ This is fundamental in representing quantum states and transformations.}
 \dfn{Outer Product}{The \textbf{outer product} \index{vector!outer product}
   of two vectors $\mathbf{v} \in \mathbb{C}^m$ and $\mathbf{w} \in
   \mathbb{C}^n$ produces an $m \times n$ matrix:
-
   \[
     \mathbf{v}\mathbf{w}^\dagger =
     \begin{bmatrix} v_1 \\ v_2 \\ \vdots \\ v_m \end{bmatrix}
@@ -116,14 +108,12 @@ This operation is useful for constructing quantum operators.}
 \dfn{Tensor Product}{The \textbf{tensor product} (or Kronecker product)
   allows us to describe multi-qubit systems. Given two vectors:
   \index{vector!tensor product}
-
   \[
     \mathbf{v} = \begin{bmatrix} v_1 \\ v_2 \end{bmatrix}, \quad
     \mathbf{w} = \begin{bmatrix} w_1 \\ w_2 \end{bmatrix}
   \]
 
   Their tensor product is:
-
   \[
     \mathbf{v} \otimes \mathbf{w} =
     \begin{bmatrix}
@@ -140,7 +130,6 @@ entangled states.}
 \subsection*{Orthagonality} \index{vector!orthogonality}
 Two vectors $v, w \in \mathbb{C}^n$ are \textbf{orthogonal} if their
 inner product is zero:
-
 \[
   \langle \mathbf{v}, \mathbf{w} \rangle = 0
 \]
@@ -181,14 +170,12 @@ This will be useful when we cover the quantum bases in \autoref{sec:lecture3}.
 \dfn{Unitary Matrix}{A square matrix $U$ is called \textbf{unitary}
   \index{matrix!unitary} if its adjoint is equal to its
   inverse:
-
   \[
     U^\dagger U = I
   \]
 
   where $I$ is the identity matrix. Unitary matrices preserve the norm of
   quantum states and represent reversible quantum operations. Example:
-
   \[
     U = \frac{1}{\sqrt{2}}
     \begin{bmatrix}
@@ -199,14 +186,12 @@ This will be useful when we cover the quantum bases in \autoref{sec:lecture3}.
 
 \dfn{Hermitian Matrix}{A square matrix $H$ is called \textbf{Hermitian}
   \index{matrix!Hermitian} if it is equal to its adjoint:
-
   \[
     H = H^\dagger
   \]
 
   Hermitian matrices represent observable quantities in quantum mechanics and
   have real eigenvalues. Example:
-
   \[
     H = \begin{bmatrix}
       2 & i \\
@@ -218,7 +203,6 @@ This will be useful when we cover the quantum bases in \autoref{sec:lecture3}.
 
   \nt{Hermitian matrices \textbf{can't} have complex numbers in their diagonal
     General case illustration:
-
     \[
       M = \begin{bmatrix} a + ib & c + id \\ e + if & g  + ih \end{bmatrix}
       \quad \Rightarrow \quad
@@ -240,7 +224,6 @@ This will be useful when we cover the quantum bases in \autoref{sec:lecture3}.
 
 Hermitian matrices are not necessarily unitary, and unitary matrices are not
 necessarily Hermitian. A matrix can be both, but these properties are distinct:
-
 \[
   H = H^\dagger \quad (\text{Hermitian}), \quad U U^\dagger = I \quad (\text{unitary})
 \]
@@ -250,7 +233,6 @@ gates) satisfy $U = U^\dagger$ and $U^2 = I$, making them their own
 inverses---they cancel out when applied twice in succession. However, not all
 unitary gates are Hermitian (e.g., the phase gate, which is unitary but not
 Hermitian):
-
 \[
   \text{Pauli } X = \begin{bmatrix} 0 & 1 \\ 1 & 0 \end{bmatrix}, \quad X = X^\dagger, \quad X^2 = I; \quad
   \text{Phase } S = \begin{bmatrix} 1 & 0 \\ 0 & i \end{bmatrix}, \quad S S^\dagger = I, \quad S \neq S^\dagger
@@ -263,7 +245,6 @@ Hermitian):
   For a square matrix $A \in \mathbb{C}^{n\times n}$, a vector
   $\mathbf{v} \neq \mathbf{0}$ is an \textbf{eigenvector} if:
   \index{vector!eigenvector}
-
   \[
     A\mathbf{v} = \lambda\mathbf{v}
   \]
@@ -273,20 +254,17 @@ Hermitian):
   \index{matrix!eigenvalue}
 
   In Braket notation, the eigenvalue equation is: \index{matrix!eigenvalue equation}
-
   \[
     A|\mathbf{v}\rangle = \lambda|\mathbf{v}\rangle
   \]
 }
 
 \ex{Example: Eigenvalues}{For the matrix
-
   \[
     A = \begin{bmatrix} 1 & i \\ -i & 1 \end{bmatrix}
   \]
 
   The characteristic equation is:
-
   \[
     \det(A - \lambda I) = (1 - \lambda)^2 + 1 = 0
   \]
@@ -295,13 +273,11 @@ Solving gives eigenvalues $\lambda = 1 \pm i$.}
 
 \dfn{Quantum Bits/ Qubits}{
   A \textbf{qubit} \index{qubit} can be defined mathematically as follows:
-
   \[
     \ket{\psi} = \bmatrix \alpha_1 \\ \alpha_2 \endbmatrix \in \mathbb{C}^2
   \]
 
   where:
-
   \[
     \alpha_1, \alpha_2 \in \mathbb{C} \quad \text{and} \quad |\alpha_1|^2 +
     |\alpha_2|^2 = 1
@@ -316,7 +292,6 @@ property ensures that the qubit is in a superposition of the basis states.
 The first universal basis that we will look at is the computational basis,
 which consists of the states \(\zero\) and \(\one\):
 \index{universal bases!computational}
-
 \[
   \text{Zero state} = \zero = \bmatrix 1 \\ 0 \endbmatrix
   \quad \text{One state} = \one = \bmatrix 0 \\ 1 \endbmatrix
@@ -324,7 +299,6 @@ which consists of the states \(\zero\) and \(\one\):
 
 A quantum state vector $\ket{\psi}$ can be expressed as a linear
 combination of the basis states:
-
 \[
   \ket{\psi} = \alpha_1\zero + \alpha_2\one
 \]
@@ -334,14 +308,12 @@ combination of the basis states:
 
   \begin{itemize}
     \item \textbf{The computational basis states are orthogonal:}
-
       \[
         \langle 0 | 1 \rangle = \zero^\dagger \one = \bmatrix 1 & 0 \endbmatrix
         \bmatrix 0 \\ 1 \endbmatrix = 0
       \]
 
     \item \textbf{The computational basis states are normalized:}
-
       \[
         \langle 0 | 0 \rangle = \zero^\dagger \zero = \bmatrix 1 & 0
         \endbmatrix \bmatrix 1 \\ 0 \endbmatrix = 1

--- a/lectures/phase-i/lecture3.tex
+++ b/lectures/phase-i/lecture3.tex
@@ -3,7 +3,6 @@
 \dfn{Qubit}{A \textbf{qubit} \index{qubit} is the fundamental unit of quantum
   information. Unlike a classical bit, which is either $0$ or $1$, a qubit
   can exist in a \vocab{superposition} \index{superposition} of states:
-
   \[
     |\psi\rangle = \alpha|0\rangle + \beta|1\rangle, \quad \text{where }
     \alpha, \beta \in \mathbb{C} \text{ and } ||\alpha||^2 + ||\beta||^2 = 1
@@ -63,7 +62,6 @@ In contrast, for quantum computing:
     basis states
 
     \ii Computational basis vectors:
-
     \[
       |0\rangle = \begin{bmatrix} 1 \\ 0 \end{bmatrix}, \quad
       |1\rangle = \begin{bmatrix} 0 \\ 1 \end{bmatrix}
@@ -80,12 +78,10 @@ In contrast, for quantum computing:
 
     \ii \textbf{Hadamard Basis:}
     \index{universal bases!Hadamard basis}
-
     \[
       |+\rangle = \frac{1}{\sqrt{2}}(|0\rangle + |1\rangle) = \begin{bmatrix}
       1/\sqrt{2} \\ 1/\sqrt{2} \end{bmatrix}
     \]
-
     \[
       |-\rangle = \frac{1}{\sqrt{2}}(|0\rangle - |1\rangle) = \begin{bmatrix}
       1/\sqrt{2} \\ -1/\sqrt{2} \end{bmatrix}
@@ -93,9 +89,7 @@ In contrast, for quantum computing:
 
     \ii \textbf{Phase/ Circular Polarization Basis:}
     \index{universal bases!phase basis}
-
     \[ |L\rangle = \ket{+i} = \frac{1}{\sqrt{2}}(|0\rangle + i|1\rangle) \]
-
     \[|R\rangle = \ket{-i} = \frac{1}{\sqrt{2}}(|0\rangle - i|1\rangle) \]
 
 \end{itemize}}
@@ -128,7 +122,6 @@ In contrast, for quantum computing:
 
 Rearranging the Bloch sphere formula, we obtain that $\theta$ and
 $\phi$ can be expressed as:
-
 \[
   \theta = 2\arccos(\alpha_1), \quad \phi = -i
   \ln\left(\frac{\alpha_2}{\sin\left(\frac{\theta}{2}\right)}\right)
@@ -141,7 +134,6 @@ $\phi$ can be expressed as:
 
 \ex{Factoring Out the Global Phase}{
   Let's say that we have the following quantum state vector $\ket{\psi}$:
-
   \[
     \begin{aligned}
       \ket{\psi} & = \frac{1}{\sqrt{2}}\lt(i \zero + \one\rt) \\

--- a/lectures/phase-i/lecture4.tex
+++ b/lectures/phase-i/lecture4.tex
@@ -10,7 +10,6 @@ representations.
   is given by:
 
   \index{qubit!superposition}
-
   \[
     |\psi\rangle = \alpha |0\rangle + \beta |1\rangle, \quad \text{where }
     \alpha, \beta \in \mathbb{C} \text{ and } |\alpha|^2 + |\beta|^2 = 1.
@@ -22,7 +21,6 @@ representations.
 
 When a qubit is measured in the computational basis $\{|0\rangle,
 |1\rangle\}$, it collapses to one of the basis states with probability:
-
 \[
   \boxed{
     P(0) = \norm{\alpha_1}^2, \quad P(1) = \norm{\alpha_2}^2.
@@ -30,7 +28,6 @@ When a qubit is measured in the computational basis $\{|0\rangle,
 \]
 
 The post-measurement state is:
-
 \[
   \boxed{
     |\psi_{\text{measurement}}\rangle = \frac{|b\rangle \langle b | \psi
@@ -47,7 +44,6 @@ postulate and ensures proper normalization of the post-measurement state.
 In the computational basis, the probability of measuring $|b\rangle$ is:
 
 \index{universal bases!computational!measurement}
-
 \[
   \boxed{
     P(b) = \norm{\langle b | \psi \rangle}^2
@@ -70,7 +66,6 @@ In the computational basis, the probability of measuring $|b\rangle$ is:
 
 \textbf{Quantum gates} are unitary matrices that transform qubits. A general
 qubit transformation is given by:
-
 \[
   |\psi_{\text{final}}\rangle = U |\psi_{\text{initial}}\rangle
 \]
@@ -213,7 +208,6 @@ quantum circuits, consider using the \texttt{quantikz} package in \LaTeX:
 
 \ex{Example: Complex Circuit Analysis}{Consider the circuit applying the
   sequence $HZH$ to $|0\rangle$:
-
   \[
     \begin{aligned}
       |\psi_1\rangle &= H|0\rangle = \frac{1}{\sqrt{2}}(|0\rangle +
@@ -228,7 +222,6 @@ quantum circuits, consider using the \texttt{quantikz} package in \LaTeX:
 
   This sequence performs a NOT operation on $|0\rangle$ using only Hadamard and
   Phase-flip gates.
-
   \[
     \begin{quantikz}
       \lstick{$|0\rangle$} & \gate{H} & \gate{Z} & \gate{H} & \one \\
@@ -237,7 +230,6 @@ quantum circuits, consider using the \texttt{quantikz} package in \LaTeX:
 }
 
 \ex{Another Circuit Example}{
-
   \[
     \begin{aligned}
       XY \zero & = X \begin{bmatrix} 0 & -i \\ i & 0 \end{bmatrix} \begin{bmatrix} 1 \\ 0 \end{bmatrix}\\
@@ -247,7 +239,6 @@ quantum circuits, consider using the \texttt{quantikz} package in \LaTeX:
       & = \begin{bmatrix} i \\ 0 \end{bmatrix} = i \one
     \end{aligned}
   \]
-
   \[
     \begin{quantikz}
       \lstick{$\zero$} & \gate{Y} & \gate{X} & i \zero \\

--- a/lectures/phase-i/lecture5.tex
+++ b/lectures/phase-i/lecture5.tex
@@ -41,7 +41,6 @@ The following are common single-qubit gates:
 
     \index{quantum gates!single-qubit gates!Phase gate}
   \item \textbf{Phase Gate (S):}
-
     \[
       \boxed{
         S = \begin{pmatrix} 1 & 0 \\ 0 & i \end{pmatrix}
@@ -64,7 +63,6 @@ The following are common single-qubit gates:
 
     \index{quantum gates!single-qubit gates!T gate}
   \item \textbf{T Gate:}
-
     \[
       \boxed{
         T = \begin{pmatrix} 1 & 0 \\ 0 & e^{i\pi/4} \end{pmatrix}
@@ -85,7 +83,6 @@ The following are common single-qubit gates:
 
     \index{quantum gates!single-qubit gates!General Phase gate}
   \item \textbf{General Phase Gate } $P(\theta)$:
-
     \[
       P(\theta) = \begin{pmatrix} 1 & 0 \\ 0 & e^{i\theta} \end{pmatrix}
     \]
@@ -165,7 +162,6 @@ The following are common single-qubit gates:
 
   States for multiple qubits are represented as
   tensor products:
-
   \[
     \boxed{
       \ket{\psi} = \sum_{k=0}^{k = 2^n-1} \alpha_k \ket{k}, \quad \sum

--- a/lectures/phase-i/lecture6.tex
+++ b/lectures/phase-i/lecture6.tex
@@ -12,7 +12,6 @@ construct quantum circuits using these gates.
 \dfn{Controlled X Gate}{(CNOT) is a two-qubit gate that flips the target qubit
   if the control qubit is in state $\ket{1}$, and does nothing if the control
   qubit is in state $\ket{0}$. The matrix representation of CNOT is given by:
-
   \[
     CNOT = CX = \begin{pmatrix}
       1 & 0 & 0 & 0 \\
@@ -93,7 +92,6 @@ Applying the CNOT gate to a two-qubit state $\ket{\psi} = \alpha\ket{00} +
 
 \dfn{Controlled-Z Gate}{(CZ) applies a phase flip if both qubits are in state
   $\ket{1}$:
-
   \[
     CZ = \begin{pmatrix}
       1 & 0 & 0 & 0 \\
@@ -106,7 +104,6 @@ Applying the CNOT gate to a two-qubit state $\ket{\psi} = \alpha\ket{00} +
 
 
 Applying the CZ gate to a 2-qubit system, we obtain:
-
 \[
   CZ \ket{00} = \ket{00}, \quad
   CZ \ket{01} = \ket{01}, \quad
@@ -149,7 +146,6 @@ mathematical representations of the same quantum circuit.
   products, we adopt the convention of representing qubits from most
   significant to least significant in our mathematical expressions. For an
   $n$-qubit system:
-
   \[
   \ket{q_{n-1}q_{n-2}...q_1q_0} = \ket{q_{n-1}} \otimes \ket{q_{n-2}} \otimes
   ... \otimes \ket{q_1} \otimes \ket{q_0}
@@ -171,7 +167,6 @@ qubits:
 \end{align*}
 
 This circuit can be represented mathematically in equivalent ways:
-
 \[
   (H \otimes H)\ket{q_1q_0} = (H\ket{q_1}) \otimes (H\ket{q_0}) = H\ket{q_1}
   \otimes H\ket{q_0}
@@ -192,7 +187,6 @@ respect these dependencies. For the CNOT gate:
 The mathematical representation must preserve the control-target
 relationship, though intermediate calculations may use different but
 equivalent orderings:
-
 \[
   CNOT_{1,0}\ket{q_1q_0} = CNOT(\ket{q_1} \otimes \ket{q_0})
 \]

--- a/lectures/phase-i/lecture7.tex
+++ b/lectures/phase-i/lecture7.tex
@@ -8,7 +8,6 @@ No-Cloning Theorem}\label{sec:lecture7}
 }
 
 \sol{\boxed{\textbf{Infinite}}
-
   \[
     P(b) = \norm{\langle b | \psi \rangle}^2
   \]
@@ -30,7 +29,6 @@ No-Cloning Theorem}\label{sec:lecture7}
 \qs{Output of Quantum Circuit}{
 
   What is the output quantum state of the following quantum circuit:
-
   \[
     \begin{quantikz}
       q_2 \quad \lstick{$\zero$} & \gate{X} & \gate{X} & \meter{} \\
@@ -64,7 +62,6 @@ No-Cloning Theorem}\label{sec:lecture7}
 
   The control and target qubits of a CNOT gate can be swapped using Hadamard
   gates:
-
   \[
     (H \otimes H) \cdot CNOT_{\text{control,target}} \cdot (H \otimes H) =
     CNOT_{\text{target,control}}
@@ -82,7 +79,6 @@ No-Cloning Theorem}\label{sec:lecture7}
   The $CX(q_0 \rightarrow q_1)$ gate, also known as $CNOT_{target,control}$,
   is a variant of the CNOT gate where the control and target qubits are
   swapped. Its matrix representation is:
-
   \[
     CNOT_{target,control} = \begin{pmatrix}
       1 & 0 & 0 & 0 \\
@@ -101,7 +97,6 @@ No-Cloning Theorem}\label{sec:lecture7}
 The control and target qubits of a CNOT gate can be swapped using Hadamard
 ($H$) gates applied to both qubits. Mathematically, this operation is
 represented as:
-
 \[
   (H \otimes H) \cdot \text{CNOT}_{\text{control,target}} \cdot (H \otimes H)
   = \text{CNOT}_{\text{target,control}}
@@ -109,7 +104,6 @@ represented as:
 
 
 The transformed CNOT gate is:
-
 \[
   (H \otimes H) \cdot \text{CNOT} \cdot (H \otimes H).
 \]
@@ -119,7 +113,6 @@ The transformed CNOT gate is:
 \textbf{Step 1: Compute $\text{CNOT} \cdot (H \otimes H)$}
 
 First, multiply the CNOT matrix with $H \otimes H$:
-
 \[
   \text{CNOT} \cdot (H \otimes H) = \begin{pmatrix}
     1 & 0 & 0 & 0 \\
@@ -135,7 +128,6 @@ First, multiply the CNOT matrix with $H \otimes H$:
 \]
 
 This results in:
-
 \[
   \text{CNOT} \cdot (H \otimes H) = \frac{1}{2} \begin{pmatrix}
     1 & 1 & 1 & 1 \\
@@ -153,7 +145,6 @@ CNOT gate's effect.
 \textbf{Step 2: Multiply $(H \otimes H)$ to the Above Result}
 
 Now, multiply $H \otimes H$ from the left:
-
 \[
   (H \otimes H) \cdot \frac{1}{2} \begin{pmatrix}
     1 & 1 & 1 & 1 \\
@@ -164,7 +155,6 @@ Now, multiply $H \otimes H$ from the left:
 \]
 
 Expanding this:
-
 \[
   \frac{1}{2} \begin{pmatrix}
     1 & 1 & 1 & 1 \\
@@ -180,7 +170,6 @@ Expanding this:
 \]
 
 After computation, the resulting matrix is:
-
 \[
   \text{CNOT}_{\text{target,control}} = \begin{pmatrix}
     1 & 0 & 0 & 0 \\
@@ -201,7 +190,6 @@ swapped.
 \dfn{SWAP Gate}{
   The SWAP gate exchanges the states of two qubits. Its matrix representation
   is:
-
   \[
     SWAP = \begin{pmatrix}
       1 & 0 & 0 & 0 \\
@@ -212,7 +200,6 @@ swapped.
   \]
 
   The action of SWAP on basis states is given by:
-
   \[
     SWAP\ket{ab} = \ket{ba}, \quad a,b \in \{0,1\}
   \]
@@ -262,7 +249,6 @@ it extends to $n$-qubits.
 
 \dfn{Toffoli Gate}{(CCX) is a three-qubit gate with two control qubits and
   one target qubit. Its matrix representation is:
-
   \[
     \textsc{Toffoli} = \begin{pmatrix}
       1 & 0 & 0 & 0 & 0 & 0 & 0 & 0 \\
@@ -331,7 +317,6 @@ As you would expect, multi-controlled $X$ gates are Hermitian.
   In this example, the quantum circuit consists of a sequence of Hermitian
   gates: the Hadamard ($H$), Pauli-Z ($Z$), and Pauli-X ($X$) gates. These
   gates satisfy the property:
-
   \[
     H = H^\dagger, \quad X = X^\dagger, \quad Z = Z^\dagger
   \]
@@ -342,7 +327,6 @@ As you would expect, multi-controlled $X$ gates are Hermitian.
 
   The circuit above first applies $H$, then $Z$, then $X$ twice (which
   cancels itself out), then $Z$ again, and finally $H$ again. This results in:
-
   \[
     H Z X X Z H = I
   \]
@@ -365,7 +349,6 @@ As you would expect, multi-controlled $X$ gates are Hermitian.
   Mathematically, if a quantum circuit is represented by a unitary matrix
   $U$, its reverse is represented by $U^{\dagger}$, and since quantum gates
   are unitary, they satisfy the property:
-
   \[
     U^{\dagger} U = U U^{\dagger} = I
   \]
@@ -379,7 +362,6 @@ As you would expect, multi-controlled $X$ gates are Hermitian.
 In classical computing, operations such as the AND gate lose information.
 For example, given the output of an AND gate, we cannot uniquely determine
 the original input:
-
 \[
   (0,0) \mapsto 0, \quad (0,1) \mapsto 0, \quad (1,0) \mapsto 0, \quad
   (1,1) \mapsto 1
@@ -442,7 +424,6 @@ reversible operations.
 
   In this example, the quantum circuit consists of a sequence of unitary
   gates: the Hadamard ($H$) and the Pauli-X ($X$) gates. These gates satisfy:
-
   \[
     H = H^\dagger, \quad X = X^\dagger
   \]
@@ -450,7 +431,6 @@ reversible operations.
   Since these gates are their own inverses (\textit{i.e.,} $H H = I$ and $X X
   = I$), if we apply the same sequence of gates in reverse order, they cancel
   out, leaving the identity operation:
-
   \[
     H X X H = I
   \]
@@ -476,14 +456,12 @@ information is conserved.
 
 \ex{Example of Reversing a Quantum Circuit}{
   Consider a circuit composed of gates $A$, $B$, and $C$:
-
   \[
     |\psi_{\text{final}}\rangle = CBA|\psi_{\text{initial}}\rangle.
   \]
 
   The reverse circuit applies $C^{\dagger}$, $B^{\dagger}$, and $A^{\dagger}$
   in reverse order:
-
   \[
     |\psi_{\text{reversed}}\rangle =
     A^{\dagger}B^{\dagger}C^{\dagger}|\psi_{\text{final}}\rangle =
@@ -504,7 +482,6 @@ information is conserved.
 
   Consider two qubits in states $\ket{\psi}$ and $\ket{0}$. The no-cloning
   theorem implies that there is no unitary operation $U$ such that:
-
   \[
     U(\ket{\psi} \otimes \ket{0}) = \ket{\psi} \otimes \ket{\psi}.
   \]
@@ -517,18 +494,15 @@ information is conserved.
   Assume a unitary operator $U$ exists that can clone an arbitrary quantum
   state $\ket{\psi}$. Then, for two different states $\ket{\psi}$ and
   $\ket{\phi}$, we would have:
-
   \[
     U(\ket{\psi} \otimes \ket{0}) = \ket{\psi} \otimes \ket{\psi},
   \]
-
   \[
     U(\ket{\phi} \otimes \ket{0}) = \ket{\phi} \otimes \ket{\phi}.
   \]
 
   Now, consider the superposition state $\ket{\xi} = a\ket{\psi} +
   b\ket{\phi}$. Applying $U$ to $\ket{\xi} \otimes \ket{0}$ should produce:
-
   \[
     U(\ket{\xi} \otimes \ket{0}) = aU(\ket{\psi} \otimes \ket{0}) +
     bU(\ket{\phi} \otimes \ket{0}) = a(\ket{\psi} \otimes \ket{\psi}) +
@@ -536,14 +510,12 @@ information is conserved.
   \]
 
   However, if $U$ could clone $\ket{\xi}$, the result should be:
-
   \[
     U(\ket{\xi} \otimes \ket{0}) = \ket{\xi} \otimes \ket{\xi} = (a\ket{\psi}
     + b\ket{\phi}) \otimes (a\ket{\psi} + b\ket{\phi}).
   \]
 
   Expanding this, we get:
-
   \[
     \ket{\xi} \otimes \ket{\xi} = a^2(\ket{\psi} \otimes \ket{\psi}) +
     ab(\ket{\psi} \otimes \ket{\phi}) + ab(\ket{\phi} \otimes \ket{\psi}) +

--- a/lectures/phase-ii/lecture10.tex
+++ b/lectures/phase-ii/lecture10.tex
@@ -19,7 +19,6 @@ to SAT}\label{sec:lecture10}
   possible $2^n$ states, allowing Grover's algorithm to explore all bitstring
   permutations simultaneously. For $n$ qubits starting at $|0\rangle^{\otimes
   n}$, applying $H^{\otimes n}$ yields:
-
   \[
     |s\rangle = H^{\otimes n} |0\rangle^{\otimes n} = \frac{1}{\sqrt{2^n}}
     \sum_{x \in \{0,1\}^n} |x\rangle.
@@ -38,7 +37,6 @@ to SAT}\label{sec:lecture10}
 
 The quantum OR gate computes $c = a \lor b$ using a combination of CNOT and
 Toffoli gates. Below is the two-way OR implementation:
-
 \[
   \begin{quantikz}
     \lstick{$|a\rangle$} & \ctrl{1} & \ctrl{2} & \qw \\
@@ -69,7 +67,6 @@ b$).
 
 A NOR gate ($c = \neg (a \lor b)$) can be implemented by adding an $X$ gate
 on the output qubit after the OR circuit:
-
 \[
   \begin{quantikz}
     \lstick{$|a\rangle$} & \ctrl{1} & \ctrl{2} & \qw \\
@@ -95,7 +92,6 @@ on the output qubit after the OR circuit:
 \subsubsection*{AND Gate}
 
 An AND gate ($c = a \land b$) is directly implemented with a Toffoli gate:
-
 \[
   \begin{quantikz}
     \lstick{$| a \rangle$} & \ctrl{1} & \qw \\
@@ -119,7 +115,6 @@ An AND gate ($c = a \land b$) is directly implemented with a Toffoli gate:
 \index{quantum gates!NAND gate}
 \subsubsection*{NAND Gate}
 A NAND gate ($c = \neg (a \land b)$) adds an $X$ gate after the AND:
-
 \[
   \begin{quantikz}
     \lstick{$|a\rangle$} & \ctrl{1} & \qw \\
@@ -150,7 +145,6 @@ A NAND gate ($c = \neg (a \land b)$) adds an $X$ gate after the AND:
   the target qubit to the control qubit(s). In Grover's algorithm, the oracle
   uses this to mark solution states. Consider a simple example with a
   controlled-$X$ and phase:
-
   \[
     \begin{quantikz}
       \lstick{$|+\rangle$} & \ctrl{1} & \qw \\
@@ -163,7 +157,6 @@ A NAND gate ($c = \neg (a \land b)$) adds an $X$ gate after the AND:
   \frac{1}{2}(|00\rangle - |01\rangle + |10\rangle - |11\rangle)$.
 
   After CNOT:
-
   \[
     \frac{1}{2}(|00\rangle - |01\rangle + |11\rangle - |10\rangle) =
     \frac{1}{\sqrt{2}}(|0\rangle - |1\rangle) \otimes \frac{1}{\sqrt{2}}(|0\rangle - |1\rangle) =

--- a/lectures/phase-ii/lecture11.tex
+++ b/lectures/phase-ii/lecture11.tex
@@ -103,7 +103,6 @@ Algebraic Normal Form (ANF) reduces this to $O(1)$ ancilla—typically one—by
 expressing the SAT problem as a single XOR polynomial.
 
 \textbf{CNF (Lecture 10):}
-
 \[
   (\neg A \lor \neg C) \land (\neg A \lor J \lor P) \land (\neg C \lor \neg
   J) \land (\neg C \lor \neg P) \land J \land (J \lor \neg P)
@@ -122,7 +121,6 @@ anf = ANFform([P, J, C, A], truth_table)  # Output: J XOR C J
 \textbf{Resulting ANF:} $f = J \oplus C J$ (simplified form from truth table).
 
 \textbf{Truth Table Verification:}
-
 \[
   \begin{array}{cccc|c}
     P & J & C & A & f \\

--- a/lectures/phase-ii/lecture8.tex
+++ b/lectures/phase-ii/lecture8.tex
@@ -6,7 +6,6 @@
 \qs{Quantum Circuit Final State}{
   Given this circuit diagram and assuming an initial state $\ket{\psi_i}
   =\ket{00}$, what will the final state $\ket{\psi_f}$ measure?
-
   \[
     \begin{quantikz}
       q_1 \quad \lstick{$\zero$} & \ctrl{0} & \gate{X} & \ctrl{1} & \swap{1}
@@ -80,7 +79,6 @@ The Bell-Pair circuit is the most analogous thing to quantum computing's
 \texttt{Hello, world!} program. It prepares a maximally entangled two-qubit
 state (a Bell state).
 
-
 \[
   \begin{quantikz}
     q_1 \quad \lstick{$\zero$} & \gate{H} & \ctrl{1} & \meter{} \\
@@ -92,19 +90,16 @@ state (a Bell state).
 \index{entanglement!proof@\textit{proof}}
 \begin{proof}{\textbf{Showing Full Entanglement Mathematically}}
   Starting with the initial state:
-
   \[
     \ket{\psi_0} = \ket{0}_1 \otimes \ket{0}_0 = \ket{00},
   \]
 
   we first apply a Hadamard gate on qubit \(q_1\):
-
   \[
     H\ket{0} = \frac{1}{\sqrt{2}}(\ket{0} + \ket{1}).
   \]
 
   Thus, the state after the Hadamard becomes:
-
   \[
     (H \otimes I)\ket{00} = \frac{1}{\sqrt{2}}(\ket{0} + \ket{1}) \otimes
     \ket{0} = \frac{1}{\sqrt{2}}(\ket{00} + \ket{10}).
@@ -112,13 +107,11 @@ state (a Bell state).
 
   Next, we apply the CNOT gate with qubit \(q_1\) as the control and qubit
   \(q_0\) as the target. The CNOT gate acts as follows:
-
   \[
     \text{CNOT}\,\ket{00} = \ket{00}, \quad \text{CNOT}\,\ket{10} = \ket{11}.
   \]
 
   Thus, the final state after the CNOT is:
-
   \[
     \boxed{
       \ket{\psi_{\text{Bell}}} = \frac{1}{\sqrt{2}}(\ket{00} + \ket{11}).
@@ -140,7 +133,6 @@ state (a Bell state).
 \begin{enumerate}
   \item Entangled circuits cannot be expressed as a product state. For
     example, the Bell state
-
     \[
       \ket{\psi_{\text{Bell}}} = \frac{1}{\sqrt{2}}(\ket{00} + \ket{11})
     \]
@@ -162,7 +154,6 @@ The Bell state can be generalized to an \(n\)-qubit system, often taking the
 form of a Greenberger–Horne–Zeilinger (GHZ) state:
 
 \index{entanglement!GHZ state}
-
 \[
   \begin{quantikz}
     q_{n - 1}\quad \lstick{$\zero$} & \gate{H} & \ctrl{1} & \qw & \qw & \qw \\
@@ -189,7 +180,6 @@ form of a Greenberger–Horne–Zeilinger (GHZ) state:
 \end{enumerate}
 
 The resulting state:
-
 \[
   \boxed{
     \ket{\psi_f} = \frac{1}{\sqrt{2}}\lt(\ket{00\cdots 00} +
@@ -210,7 +200,6 @@ match the measured value.
 }
 
 \ex{Alternative $n$-Qubit Bell Circuit}{
-
   \[
     \begin{quantikz}
       q_{n-1} \quad \lstick{$\zero$} & \gate{H} & \ctrl{1} & \ctrl{2} &
@@ -256,7 +245,6 @@ match the measured value.
 
 There also exists the middle ground of partially-entangled systems where only
 some of the qubits are entangled while others have independent states.
-
 \[
   \begin{quantikz}
     q_2 \quad \lstick{$\zero$} & \gate{H} & \qw & \qw \\
@@ -268,7 +256,6 @@ some of the qubits are entangled while others have independent states.
 In this case, \(q_1\) and \(q_0\) become entangled through the CNOT gate,
 while \(q_2\) remains in a superposition state but independent of the other
 qubits. The final state is:
-
 \[
   \ket{\psi_f} = \frac{1}{\sqrt{2}}\ket{+}_2 \otimes
   \frac{1}{\sqrt{2}}(\ket{00}_{10} + \ket{11}_{10})

--- a/lectures/phase-ii/lecture9.tex
+++ b/lectures/phase-ii/lecture9.tex
@@ -7,7 +7,6 @@
 \subsection*{Problem Statement}
 
 Given a bitstring \( x \in \{0, 1\}^n \) and a function
-
 \[
   f(x) =
   \begin{cases}
@@ -40,7 +39,6 @@ The general structure of Grover's algorithm is as follows:
   \item \textbf{State Preparation:} Initialize all qubits in the state
     \(\ket{0}^{\otimes n}\) and apply \( H^{\otimes n} \) to create a uniform
     superposition:
-
     \[
       \ket{s} = H^{\otimes n} \ket{0}^{\otimes n} = \frac{1}{\sqrt{2^n}}
       \sum_{x \in \{0,1\}^n} \ket{x}.
@@ -52,7 +50,6 @@ The general structure of Grover's algorithm is as follows:
     \begin{itemize}
       \item \textbf{Oracle \(O\):} Flip the phase of the marked state(s);
         that is, for every \( x \),
-
         \[
           O \ket{x} = (-1)^{f(x)} \ket{x}.
         \]
@@ -62,13 +59,11 @@ The general structure of Grover's algorithm is as follows:
 
       \item \textbf{Diffusion Operator \(D\):} Reflect all amplitudes about
         the average amplitude. This operator is given by
-
         \[
           D = 2\ket{s}\bra{s} - I.
         \]
 
         In practice, \( D \) is implemented as
-
         \[
           D = H^{\otimes n} \; X^{\otimes n} \; (CZ) \; X^{\otimes n} \;
           H^{\otimes n},
@@ -81,7 +76,6 @@ The general structure of Grover's algorithm is as follows:
 \end{enumerate}
 
 The high-level circuit for an \( n \)-qubit Grover algorithm is illustrated as:
-
 \[
 \begin{quantikz}
   \lstick{$q_{n - 1}$} & \gate{H} &  \gate[5]{\shortstack{$f(x)$ \\ Oracle}} & \qw & \gate[5]{\text{Diffusion Circuit}} & \meter{} \\
@@ -91,7 +85,6 @@ The high-level circuit for an \( n \)-qubit Grover algorithm is illustrated as:
   \lstick{$q_0$} & \gate{H} &  & & & \meter{}
 \end{quantikz}
 \]
-
 \[
   \hspace{1.5cm}
   \underbrace{\hspace{6cm}}_{\text{Repeat } \sqrt{2^n} \text{ times}}
@@ -177,7 +170,6 @@ which multiplies the state \(\ket{11}\) by \(-1\).
 \vspace{0.3cm}
 
 \textbf{Diffusion Operator:} For 2 qubits, the diffusion operator is given by:
-
 \[
   D = H^{\otimes 2}\; X^{\otimes 2}\; CZ\; X^{\otimes 2}\; H^{\otimes 2}.
 \]
@@ -185,7 +177,6 @@ which multiplies the state \(\ket{11}\) by \(-1\).
 \vspace{0.3cm}
 
 \textbf{2-Qubit Grover Circuit:}
-
 \[
 \begin{quantikz}
   \lstick{$\ket{0}$} & \gate{H} & \ctrl{1} & \gate{H} & \gate{X} & \qw & \ctrl{1} & \qw & \gate{X} & \gate{H} & \meter{} \\
@@ -225,7 +216,6 @@ Grover's algorithm can be summarized in the following pseudocode:
   \ket{0}^{\otimes n} \).\\
 
   Apply \( H^{\otimes n} \) to obtain the uniform superposition:
-
   \[
     \ket{s} = H^{\otimes n}\ket{0}^{\otimes n} = \frac{1}{\sqrt{2^n}} \sum_{x
     \in \{0,1\}^n} \ket{x}.
@@ -235,7 +225,6 @@ Grover's algorithm can be summarized in the following pseudocode:
   \right\rfloor \)}{
 
     Apply the Oracle \( O \) which performs:
-
     \[
       O\ket{x} = (-1)^{f(x)}\ket{x},
     \]

--- a/lectures/phase-iii/lecture12.tex
+++ b/lectures/phase-iii/lecture12.tex
@@ -103,7 +103,6 @@ measurement outcomes. Key features include:
 \end{itemize}
 
 The general process is depicted as:
-
 \[
   \ket{\psi(\theta)} \xrightarrow{\text{varying circuit}} \text{Measure }
   C(\theta) \xrightarrow{\text{classical optimization}} \theta_{\text{opt}}

--- a/lectures/phase-iii/lecture13.tex
+++ b/lectures/phase-iii/lecture13.tex
@@ -241,7 +241,6 @@ states, enabling exploration of the solution space.
 
 \ex{Simplified \textsc{Max-Cut} Circuit ($P=1$)}{
   The QAOA ansatz for $P=1$ can be represented at a higher level as:
-
   \[
     \begin{quantikz}
       \lstick{$q_0: \ket{0}$} & \gate{H} & \gate{e^{-i\gamma Z_0 Z_1}} & \gate{e^{-i\gamma Z_3 Z_0}} & \gate{R_X(2\beta)} & \meter{} \\

--- a/lectures/phase-iii/lecture14.tex
+++ b/lectures/phase-iii/lecture14.tex
@@ -91,7 +91,6 @@ solution of the classical problem.}
 The operator $e^{-i\gamma H_C}$ can be challenging to implement directly.
 When $H_C$ consists of terms that commute with each other, we can decompose
 the exponential:
-
 \[
   e^{-i\gamma H_C} = e^{-i\gamma \sum_j h_j} = \prod_j e^{-i\gamma h_j}
 \]

--- a/lectures/phase-iii/lecture15.tex
+++ b/lectures/phase-iii/lecture15.tex
@@ -197,7 +197,6 @@ MaxCut in PennyLane:
   \textbf{QUBO} is a mathematical optimization model involving binary
   variables with a quadratic objective function. It can be expressed as
   minimizing:
-
   \[
     f(\mathbf{x}) = \mathbf{x}^T Q \mathbf{x} = \sum_{i=1}^n \sum_{j=1}^n Q_{ij}x_i x_j
   \]

--- a/lectures/phase-iv/lecture16.tex
+++ b/lectures/phase-iv/lecture16.tex
@@ -4,7 +4,6 @@
 
 \qs{Number of $CX$ Gates}{
   How many $CX$ gates are required to implement the following QUBO cost function:
-
   \[
     c(x) = 0.1x_1x_2 + 0.0x_0x_2 + 0.2x_1x_2 + 0.3x_0x_1
   \]
@@ -22,7 +21,6 @@
 
   These interactions suggest 4 distinct $CX$ gates are required, noting that
   repeated interactions don't necessarily increase gate count.
-
   \[
     \boxed{4}
   \]
@@ -84,7 +82,6 @@ scenarios where:
 
 \ex{Gate Deletion Example}{
 Consider a circuit with successive rotations:
-
 \[
   R_z(\pi/2) \circ R_z(-\pi/2) \equiv \text{Identity}
 \]

--- a/lectures/phase-iv/lecture17.tex
+++ b/lectures/phase-iv/lecture17.tex
@@ -31,7 +31,6 @@ compiler-level optimizations.
 
 \ex{Gate Commutativity Example}{
   Consider two single-qubit rotations:
-
   \[
     R_z(\alpha) \circ R_x(\beta) \approx R_x(\beta) \circ R_z(\alpha)
   \]

--- a/lectures/phase-iv/lecture19.tex
+++ b/lectures/phase-iv/lecture19.tex
@@ -57,7 +57,6 @@ decomposes into three CX gates, amplifying the importance of efficient mapping.
 
   Consider a simple logical circuit with a single CNOT gate between two qubits,
   q0 and q1:
-
   \[
     \begin{quantikz}
       \qw & \ctrl{1} & \qw \\
@@ -73,7 +72,6 @@ decomposes into three CX gates, amplifying the importance of efficient mapping.
 
   Map q0 to p0 and q1 to p1, where p0 and p1 are adjacent. The physical circuit
   remains:
-
   \[
     \begin{quantikz}
       \lstick{p0 (q0)} & \ctrl{1} & \qw \\
@@ -98,7 +96,6 @@ decomposes into three CX gates, amplifying the importance of efficient mapping.
   \end{enumerate}
 
   The physical circuit becomes:
-
   \[
     \begin{quantikz}
       \lstick{p0 (q0)} & \qw & \qw & \ctrl{1} & \qw & \qw \\
@@ -155,7 +152,6 @@ Heavy-hex Architecture} for mapping optimization techniques.}
 \ex{Larger Circuit Mapping Example}{
 
   Consider a three-qubit logical circuit:
-
   \[
     \begin{quantikz}
       \lstick{q0} & \ctrl{1} & \qw & \ctrl{2} & \qw \\
@@ -167,7 +163,6 @@ Heavy-hex Architecture} for mapping optimization techniques.}
 
   On a heavy-hex segment (p0-p1-p2), an optimal mapping (q0 to p0, q1 to p1, q2
   to p2) executes the first two gates directly but requires a SWAP for CX q0 q2:
-
   \[
     \begin{quantikz}
       \lstick{p0 (q0)} & \ctrl{1} & \qw & \qw & \ctrl{1} & \qw \\

--- a/lectures/phase-iv/lecture20.tex
+++ b/lectures/phase-iv/lecture20.tex
@@ -20,7 +20,6 @@ mechanics.
 Classical bits, which can be either 0 or 1, are prone to errors with a
 probability \( p \in [0, 1] \), where the bit flips with probability \( p \)
 and remains correct with probability \( 1 - p \). This is formally expressed as:
-
 \[
   b =
   \begin{cases}
@@ -106,7 +105,6 @@ multiple physical qubits, using codes like the repetition code.
   This is achieved by starting with the initial qubit in \( |\psi\rangle \)
   and two ancilla qubits in \( |0\rangle \), then applying CNOT gates from
   the original qubit to the ancillas:
-
   \[
     \begin{quantikz}
       \lstick{$q_0 \: \ket{\psi}$} & \ctrl{1} & \ctrl{2} & \qw \\

--- a/lectures/phase-iv/lecture21.tex
+++ b/lectures/phase-iv/lecture21.tex
@@ -40,7 +40,6 @@ The logical states are:
 For an arbitrary state \( |\psi\rangle = \alpha |0\rangle + \beta |1\rangle
 \), the encoded state is \( \alpha |+++\rangle + \beta |---\rangle \). The
 encoding circuit is:
-
 \[
   \begin{quantikz}
     \lstick{$q_2 : |\psi\rangle$} & \gate{H} & \ctrl{1} & \ctrl{2} & \gate{H} & \qw \\
@@ -65,7 +64,6 @@ To detect a phase flip (e.g., \( Z \) on \( q_1 \)), we measure syndromes
 using ancilla qubits in the Hadamard basis. A \( Z \) error on \( q_1 \)
 flips \( |+++\rangle \to |+-+\rangle \) or \( |---\rangle \to |-+-\rangle \).
 The syndrome measurement circuit is:
-
 \[
   \begin{quantikz}
     \lstick{$q_2$} & \gate{H} & \ctrl{3} & \qw & \qw & \gate{H} & \qw \\
@@ -141,7 +139,6 @@ The encoding circuit generalizes to:
 
 \noindent
 For \( n = 5 \), the circuit is:
-
 \[
   \begin{quantikz}
     \lstick{$q_4 : |\psi\rangle$} & \gate{H} & \ctrl{1} & \ctrl{2} & \ctrl{3} & \ctrl{4} & \gate{H} & \qw \\
@@ -171,7 +168,6 @@ higher-distance codes.
 
   Consider a Bell state preparation circuit, creating \( |\Phi^+\rangle =
   \frac{|00\rangle + |11\rangle}{\sqrt{2}} \):
-
   \[
     \begin{quantikz}
       \lstick{$q_1 : |0\rangle$} & \gate{H} & \ctrl{1} & \qw \\
@@ -185,7 +181,6 @@ higher-distance codes.
   |---\rangle}{\sqrt{2}} \), and similarly for \( q_0 : |0\rangle \). The
   encoded circuit, adapted for phase flip protection, requires 6 qubits (3 per
   logical qubit):
-
   \[
     \begin{quantikz}
       \lstick{$q_{1,0} : |0\rangle$} & \gate{H} & \ctrl{1} & \ctrl{2} & \gate{H} & \ctrl{3} & \qw \\


### PR DESCRIPTION
Those introduces the possibility of a page break before the display equation, which is considered bad practice.

I also simplified the code in the preface.