### PR TITLE
Make LaTeX Logo Upright

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The latest version of these notes is available at [micahkepe.com/comp458-notes](
 
 This repository is meant as an educational resource and collaboration space
 for reinforcing the concepts learned in the course. The notes are written fully
-in $\LaTeX$.
+in $\text\LaTeX$.
 
 > [!IMPORTANT]
 > These notes are a work-in-progress and will undergo updates and revisions


### PR DESCRIPTION
In real LaTeX, \LaTeX in math mode isn't allowed, but the web version renders it as italic; add \text before it to make it upright in the README.